### PR TITLE
Handle missing JWT secret in authentication middleware

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -9,6 +9,13 @@ export function authenticate(req, res, next) {
     return res.status(401).json({ error: "Unauthorized: No token provided" });
   }
 
+  if (!SECRET_KEY) {
+    console.error("JWT secret key is not defined");
+    return res
+      .status(500)
+      .json({ error: "Internal server error: missing secret key" });
+  }
+
   try {
     const decoded = jwt.verify(token, SECRET_KEY);
     req.user = decoded; // Attach user info to the request object


### PR DESCRIPTION
## Summary
- Verify that `JWT_SECRET` is defined before attempting token verification
- Return a 500 error and log an error when the secret key is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689540db6eb0832aaa2e2a3363c05651