### PR TITLE
Fix mobile clip-path border for login and search pages

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -55,17 +55,19 @@
   <!-- Main content area, shifted right on desktop / below nav on mobile -->
   <div class="app-container">
     <main class="login-main">
-      <section class="login-container">
-        <form id="loginForm" class="login-form">
-          <label for="username" class="login-label">ユーザー名:</label>
-          <input type="text" id="username" name="username" class="login-input" placeholder="ユーザー名" required />
+      <section class="login-card">
+        <div class="login-container">
+          <form id="loginForm" class="login-form">
+            <label for="username" class="login-label">ユーザー名:</label>
+            <input type="text" id="username" name="username" class="login-input" placeholder="ユーザー名" required />
 
-          <label for="password" class="login-label">パスワード:</label>
-          <input type="password" id="password" name="password" class="login-input" placeholder="パスワード" required />
+            <label for="password" class="login-label">パスワード:</label>
+            <input type="password" id="password" name="password" class="login-input" placeholder="パスワード" required />
 
-          <button type="submit" class="login-button">ログイン</button>
-        </form>
-        <div id="loginMessage" class="login-message"></div>
+            <button type="submit" class="login-button">ログイン</button>
+          </form>
+          <div id="loginMessage" class="login-message"></div>
+        </div>
       </section>
     </main>
   </div>

--- a/public/styles/local-styles/login.css
+++ b/public/styles/local-styles/login.css
@@ -57,20 +57,21 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+/* wrapper that holds drop-shadows for clip-path card */
+.login-card {
+    filter: drop-shadow(1px 0 0 var(--accent-color))
+            drop-shadow(-1px 0 0 var(--accent-color))
+            drop-shadow(0 1px 0 var(--accent-color))
+            drop-shadow(0 -1px 0 var(--accent-color))
+            drop-shadow(0 0 10px rgba(var(--accent), .3));
 
-    filter: drop-shadow(1px 0 0 var(--accent-color)) 
-    drop-shadow(-1px 0 0 var(--accent-color)) 
-    drop-shadow(0 1px 0 var(--accent-color)) 
-    drop-shadow(0 -1px 0 var(--accent-color)) 
-    drop-shadow(0 0 10px rgba(var(--accent), .3));
-    
-    -webkit-filter: drop-shadow(1px 0 0 var(--accent-color)) 
-                drop-shadow(-1px 0 0 var(--accent-color)) 
-                drop-shadow(0 1px 0 var(--accent-color)) 
-                drop-shadow(0 -1px 0 var(--accent-color)) 
-                drop-shadow(0 0 10px rgba(var(--accent), .3));
+    -webkit-filter: drop-shadow(1px 0 0 var(--accent-color))
+                    drop-shadow(-1px 0 0 var(--accent-color))
+                    drop-shadow(0 1px 0 var(--accent-color))
+                    drop-shadow(0 -1px 0 var(--accent-color))
+                    drop-shadow(0 0 10px rgba(var(--accent), .3));
     position: relative;
-    /* keeps ::after of inner in place */
 }
 
 .login-container {
@@ -207,17 +208,10 @@
             calc(var(--border-width)) calc(100% - var(--border-width)));
 }
 
-.login-button:hover {
-    color: var(--text-color);
-  }
 
-.login-button:hover::after {
-    background: rgb(17, 17, 21);
-}
-
-.login-button:hover::before {
-    background: linear-gradient(to bottom right, var(--accent-color), var(--words-color));
-    filter: brightness(1.3);
+/* active state resets hover translation */
+.login-button:active {
+    transform: translateY(0);
 }
 
 .login-message {
@@ -257,4 +251,24 @@
         margin-left: 0;
         padding-top: var(--btn-size-mobile);
     }
+}
+
+/* Improve performance while not making dumb GPU crash stuff happen on mobile */
+@media (hover:hover) {
+
+  /* desktop / laptop */
+  .login-button:hover {
+    color: var(--text-color);
+    transform: translateY(-1px);
+    will-change: transform;
+  }
+
+  .login-button:hover::after {
+    background: rgb(17, 17, 21);
+  }
+
+  .login-button:hover::before {
+    background: linear-gradient(to bottom right, var(--accent-color), var(--words-color));
+    filter: brightness(1.3);
+  }
 }

--- a/public/styles/local-styles/search.css
+++ b/public/styles/local-styles/search.css
@@ -129,18 +129,17 @@
 
 .search-controls__form-wrapper {
   position: relative;
-  filter:
-    drop-shadow(1px 0 0 var(--accent-color))
-    drop-shadow(-1px 0 0 var(--accent-color))
-    drop-shadow(0 1px 0 var(--accent-color))
-    drop-shadow(0 -1px 0 var(--accent-color))
-    drop-shadow(0 0 10px rgba(var(--accent), .3));
-  -webkit-filter:
-    drop-shadow(1px 0 0 var(--accent-color))
-    drop-shadow(-1px 0 0 var(--accent-color))
-    drop-shadow(0 1px 0 var(--accent-color))
-    drop-shadow(0 -1px 0 var(--accent-color))
-    drop-shadow(0 0 10px rgba(var(--accent), .3));
+  /* Mobile clip-path border fix */
+  filter: drop-shadow(1px 0 0 var(--accent-color))
+          drop-shadow(-1px 0 0 var(--accent-color))
+          drop-shadow(0 1px 0 var(--accent-color))
+          drop-shadow(0 -1px 0 var(--accent-color))
+          drop-shadow(0 0 10px rgba(var(--accent), .3));
+  -webkit-filter: drop-shadow(1px 0 0 var(--accent-color))
+                  drop-shadow(-1px 0 0 var(--accent-color))
+                  drop-shadow(0 1px 0 var(--accent-color))
+                  drop-shadow(0 -1px 0 var(--accent-color))
+                  drop-shadow(0 0 10px rgba(var(--accent), .3));
 }
 
 /* inner plate */
@@ -241,8 +240,6 @@
 }
 .search-controls__button::before { content: ''; position: absolute; inset: 0; background: var(--border-color); z-index: -2; transition: filter .2s; }
 .search-controls__button::after  { content: ''; position: absolute; inset: 0; background: var(--background-color); z-index: -1; clip-path: polygon(var(--border-width) calc(var(--edge-size) + var(--border-width) * .5), calc(var(--edge-size) + var(--border-width) * .5) var(--border-width), calc(100% - var(--border-width)) var(--border-width), calc(100% - var(--border-width)) calc(100% - calc(var(--edge-size) + var(--border-width) * .5)), calc(100% - calc(var(--edge-size) + var(--border-width) * .5)) calc(100% - var(--border-width)), calc(var(--border-width)) calc(100% - var(--border-width))); }
-.search-controls__button:hover { color: var(--text-color); transform: translateY(-1px); }
-.search-controls__button:hover::before { background: linear-gradient(to bottom right, var(--accent-color), var(--words-color)); filter: brightness(1.25); }
 .search-controls__button:active { transform: translateY(0); }
 .search-controls__button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent), .22); }
 
@@ -274,7 +271,6 @@
   box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3);
   transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease, background 140ms ease, filter 140ms ease;
 }
-.mode-chip:hover { transform: translateY(-1px); filter: brightness(1.06); }
 .mode-chip:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent), .45); }
 .chip-key { font-size: clamp(10px, .7vw, 12px); padding: 2px 6px; display: none; }
 .chip-jp  { font-weight: 700; line-height: 1.2; font-size: clamp(13px, .95vw, 20px); }
@@ -459,5 +455,26 @@
   .search-controls__button {
     width: 100%;
     margin-left: 0;
+  }
+}
+
+/* Improve performance while not making dumb GPU crash stuff happen on mobile */
+@media (hover:hover) {
+
+  .search-controls__button:hover {
+    color: var(--text-color);
+    transform: translateY(-1px);
+    will-change: transform;
+  }
+
+  .search-controls__button:hover::before {
+    background: linear-gradient(to bottom right, var(--accent-color), var(--words-color));
+    filter: brightness(1.25);
+  }
+
+  .mode-chip:hover {
+    transform: translateY(-1px);
+    filter: brightness(1.06);
+    will-change: transform;
   }
 }


### PR DESCRIPTION
## Summary
- wrap login button and search controls hover styles in a `@media (hover:hover)` block to avoid mobile GPU crashes
- keep active states outside the hover-only block for consistent press feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966f77b180832a87da12238ed001ef