### PR TITLE
fix: disable hotkeys while typing in any search field

### DIFF
--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -164,7 +164,7 @@ function initModeRail() {
     el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable);
 
   document.addEventListener("keydown", (e) => {
-    if (isTypingTarget(e.target) && e.target.id === "search-input") return;
+    if (isTypingTarget(e.target)) return;
 
     if (/^[1-6]$/.test(e.key)) {
       activateByIndex(parseInt(e.key, 10) - 1, { focus: true });


### PR DESCRIPTION
## Summary
- prevent mode hotkeys from firing when any form field has focus on the search page