### PR TITLE
Focus search input after mode switch

### DIFF
--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -136,6 +136,8 @@ function initModeRail() {
     if (dispatch) searchTypeSelect.dispatchEvent(new Event("change", { bubbles: true }));
     syncAccent(value);
 
+    if (searchInput) searchInput.focus({ preventScroll: true });
+
     // After the first activation, enable transitions
     if (!animateEnabled) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
- focus search box when switching search modes so typing can start immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68975cd0eee0832a9fbe3da17e4637f8